### PR TITLE
Document submodule fetch and add helper script

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,5 @@
+.PHONY: submodules
+
+# Fetch all submodules
+submodules:
+	git submodule update --init --recursive

--- a/README.md
+++ b/README.md
@@ -2,11 +2,21 @@
 
 This repository acts as a container for multiple git submodules that hold the main application code.
 
-To set up this project after cloning, initialize and update the submodules with:
+## Fetching submodules
+
+Clone the repository and fetch all submodules in one step:
+
+```bash
+git clone --recurse-submodules <repo-url>
+```
+
+If you have already cloned the repository without submodules, initialize and update them with:
 
 ```bash
 git submodule update --init --recursive
 ```
+
+You can also run `scripts/update_submodules.sh` or `make submodules` to execute the same command.
 
 The directories `hrishikesh` and `hrishikesh-dashboard` will then contain their respective codebases.
 

--- a/scripts/update_submodules.sh
+++ b/scripts/update_submodules.sh
@@ -1,0 +1,7 @@
+#!/usr/bin/env bash
+# Update git submodules recursively
+set -e
+
+# Run the standard submodule update command
+
+git submodule update --init --recursive


### PR DESCRIPTION
## Summary
- document how to fetch submodules
- add a script to update submodules
- provide `make submodules` target

## Testing
- `make submodules` *(fails: unable to access github.com)*
- `./scripts/update_submodules.sh` *(fails: unable to access github.com)*

------
https://chatgpt.com/codex/tasks/task_e_686e70dc91a4832db942d2def5f8e4bd